### PR TITLE
Fix RCC_PLLCFGR register fixup for F4s

### DIFF
--- a/svd/src/lib.rs
+++ b/svd/src/lib.rs
@@ -108,6 +108,7 @@ fn patch_stm32f401(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f405(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     rcc::fix_3(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     dma::fix_dma2_2(&mut dev)?;
@@ -128,6 +129,7 @@ fn patch_stm32f405(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f407(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     rcc::fix_3(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     dma::fix_dma2_2(&mut dev)?;
@@ -148,6 +150,7 @@ fn patch_stm32f407(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f410(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     tim::fix_tim1_1(&mut dev)?;
     tim::fix_tim5_1(&mut dev)?;
@@ -161,6 +164,7 @@ fn patch_stm32f410(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f411(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     tim::fix_tim1_1(&mut dev)?;
     tim::fix_tim2_2(&mut dev)?;
@@ -178,6 +182,7 @@ fn patch_stm32f411(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f412(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     tim::fix_tim1_1(&mut dev)?;
     tim::fix_tim2_2(&mut dev)?;
@@ -198,6 +203,7 @@ fn patch_stm32f412(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f413(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     dma::fix_dma1_1(&mut dev)?;
     exti::fix_exti_2(&mut dev)?;
     tim::fix_tim1_1(&mut dev)?;
@@ -217,6 +223,7 @@ fn patch_stm32f413(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f427(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     rcc::fix_3(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     dma::fix_dma2_2(&mut dev)?;
@@ -236,6 +243,7 @@ fn patch_stm32f427(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f429(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     rcc::fix_3(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     dma::fix_dma2_2(&mut dev)?;
@@ -255,6 +263,7 @@ fn patch_stm32f429(mut dev: Device) -> Result<Device> {
 }
 
 fn patch_stm32f446(mut dev: Device) -> Result<Device> {
+    rcc::fix_2(&mut dev)?;
     dma::fix_dma2_1(&mut dev)?;
     dma::fix_dma2_2(&mut dev)?;
     tim::fix_tim1_1(&mut dev)?;


### PR DESCRIPTION
Call rcc::fix_2 on those F4 processors which have the RCC PLLCFGR field splitout by bit for the PLLM, PLLN, PLLP, and PLLQ fields.