### PR TITLE
Add uart3 for stm32f429

### DIFF
--- a/src/periph/uart/f4.rs
+++ b/src/periph/uart/f4.rs
@@ -349,6 +349,7 @@ map_uart! {
 
 #[cfg(any(
     stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
 ))]
 map_uart! {
     "Extracts USART3 register tokens.",

--- a/tests/periph_macros.rs
+++ b/tests/periph_macros.rs
@@ -1171,6 +1171,7 @@ fn periph_macros1() {
             stm32_mcu = "stm32f413",
             stm32_mcu = "stm32f417",
             stm32_mcu = "stm32f427",
+            stm32_mcu = "stm32f429",
             stm32_mcu = "stm32f437",
             stm32_mcu = "stm32f446",
             stm32_mcu = "stm32f469",


### PR DESCRIPTION
The stm32f429 has a usart3 which is not included in the f4 uart branch.