### PR TITLE
Add UART peripheral bindings for STM32F4 series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 ### Unreleased
+- [added] Add support for 'uart' on STM32F4 series
 
 ### v0.13.0 (2020-11-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 ### Unreleased
+
 - [added] Add support for 'uart' on STM32F4 series
 
 ### v0.13.0 (2020-11-28)

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ drop-in replacement for it.
 | `stm32f103` | ARM® Cortex®-M3 r1p1  | [RM0008](https://www.st.com/resource/en/reference_manual/cd00171190.pdf) | `dma` `gpio` `spi` `tim`                                 |
 | `stm32f107` | ARM® Cortex®-M3 r1p1  | [RM0008](https://www.st.com/resource/en/reference_manual/cd00171190.pdf) | `dma` `gpio` `spi` `tim`                                 |
 | `stm32f303` | ARM® Cortex®-M4F r0p1 | [RM0316](https://www.st.com/resource/en/reference_manual/dm00043574.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f401` | ARM® Cortex®-M4F r0p1 | [RM0368](https://www.st.com/resource/en/reference_manual/dm00096844.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f405` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f407` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f410` | ARM® Cortex®-M4F r0p1 | [RM0401](https://www.st.com/resource/en/reference_manual/dm00180366.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f411` | ARM® Cortex®-M4F r0p1 | [RM0383](https://www.st.com/resource/en/reference_manual/dm00119316.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f412` | ARM® Cortex®-M4F r0p1 | [RM0402](https://www.st.com/resource/en/reference_manual/dm00180369.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f413` | ARM® Cortex®-M4F r0p1 | [RM0430](https://www.st.com/resource/en/reference_manual/dm00305666.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f427` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f429` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f446` | ARM® Cortex®-M4F r0p1 | [RM0390](https://www.st.com/resource/en/reference_manual/dm00135183.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
-| `stm32f469` | ARM® Cortex®-M4F r0p1 | [RM0386](https://www.st.com/resource/en/reference_manual/dm00127514.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim`                    |
+| `stm32f401` | ARM® Cortex®-M4F r0p1 | [RM0368](https://www.st.com/resource/en/reference_manual/dm00096844.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f405` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f407` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f410` | ARM® Cortex®-M4F r0p1 | [RM0401](https://www.st.com/resource/en/reference_manual/dm00180366.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f411` | ARM® Cortex®-M4F r0p1 | [RM0383](https://www.st.com/resource/en/reference_manual/dm00119316.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f412` | ARM® Cortex®-M4F r0p1 | [RM0402](https://www.st.com/resource/en/reference_manual/dm00180369.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f413` | ARM® Cortex®-M4F r0p1 | [RM0430](https://www.st.com/resource/en/reference_manual/dm00305666.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f427` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f429` | ARM® Cortex®-M4F r0p1 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f446` | ARM® Cortex®-M4F r0p1 | [RM0390](https://www.st.com/resource/en/reference_manual/dm00135183.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
+| `stm32f469` | ARM® Cortex®-M4F r0p1 | [RM0386](https://www.st.com/resource/en/reference_manual/dm00127514.pdf) | `adc` `dma` `exti` `gpio` `i2c` `tim` `uart`             |
 | `stm32l4x1` | ARM® Cortex®-M4F r0p1 | [RM0394](https://www.st.com/resource/en/reference_manual/dm00151940.pdf) | `dma` `exti` `gpio` `i2c` `rtc` `spi` `tim` `uart`       |
 | `stm32l4x2` | ARM® Cortex®-M4F r0p1 | [RM0394](https://www.st.com/resource/en/reference_manual/dm00151940.pdf) | `dma` `exti` `gpio` `i2c` `rtc` `spi` `tim` `uart`       |
 | `stm32l4x3` | ARM® Cortex®-M4F r0p1 | [RM0394](https://www.st.com/resource/en/reference_manual/dm00151940.pdf) | `dma` `exti` `gpio` `i2c` `rtc` `spi` `tim` `uart`       |
@@ -55,7 +55,7 @@ this table.
 ## Documentation
 
 - [Drone Book](https://book.drone-os.com/)
-- [API documentation](https://api.drone-os.com/drone-stm32-map/0.12/)
+- [API documentation](https://api.drone-os.com/drone-stm32-map/0.14/)
 
 The API documentation intentionally skips auto-generated [`reg`] and [`thr`]
 bindings. Otherwise it would use several gigabytes of space and would be
@@ -69,7 +69,7 @@ Add the crate to your `Cargo.toml` dependencies:
 
 ```toml
 [dependencies]
-drone-stm32-map = { version = "0.12.3", features = [...] }
+drone-stm32-map = { version = "0.14.0", features = [...] }
 ```
 
 Add or extend `std` feature as follows:

--- a/src/periph/uart/f4.rs
+++ b/src/periph/uart/f4.rs
@@ -1,0 +1,747 @@
+//! Universal Asynchronous Receiver/Transmitter.
+//!
+//! For STM32F4 series of high-performance MCUs with DSP and FPU instructions.
+
+use drone_core::periph;
+use drone_cortexm::reg::marker::*;
+
+periph! {
+    /// Generic UART peripheral variant.
+    pub trait UartMap {}
+
+    /// Generic UART peripheral.
+    pub struct UartPeriph;
+
+    RCC {
+        BUSENR {
+            0x20 RwRegBitBand Shared;
+            UARTEN { RwRwRegFieldBitBand }
+        }
+        BUSRSTR {
+            0x20 RwRegBitBand Shared;
+            UARTRST { RwRwRegFieldBitBand }
+        }
+        BUSSMENR {
+            0x20 RwRegBitBand Shared;
+            UARTSMEN { RwRwRegFieldBitBand }
+        }
+    }
+
+    UART {
+        SR {
+            0x20 RwRegBitBand;
+            CTS { RwRwRegFieldBit Option }
+            LBD { RwRwRegFieldBit }
+            TXE { RoRwRegFieldBit }
+            TC { RwRwRegFieldBit }
+            RXNE { RwRwRegFieldBit }
+            IDLE { RoRwRegFieldBit }
+            ORE { RoRwRegFieldBit }
+            NF { RoRwRegFieldBit }
+            FE { RoRwRegFieldBit }
+            PE { RoRwRegFieldBit }
+        }
+        DR {
+            0x20 RwRegBitBand;
+            DR { RwRwRegFieldBits }
+        }
+        BRR {
+            0x20 RwRegBitBand;
+            DIV_Mantissa { RwRwRegFieldBits }
+            DIV_Fraction { RwRwRegFieldBits }
+        }
+        CR1 {
+            0x20 RwRegBitBand;
+            OVER8 { RwRwRegFieldBit }
+            UE { RwRwRegFieldBit }
+            M { RwRwRegFieldBit }
+            WAKE { RwRwRegFieldBit }
+            PCE { RwRwRegFieldBit }
+            PS { RwRwRegFieldBit }
+            PEIE { RwRwRegFieldBit }
+            TXEIE { RwRwRegFieldBit }
+            TCIE { RwRwRegFieldBit }
+            RXNEIE { RwRwRegFieldBit }
+            IDLEIE { RwRwRegFieldBit }
+            TE { RwRwRegFieldBit }
+            RE { RwRwRegFieldBit }
+            RWU { RwRwRegFieldBit }
+            SBK { RwRwRegFieldBit }
+        }
+        CR2 {
+            0x20 RwRegBitBand;
+            LINEN { RwRwRegFieldBit }
+            STOP { RwRwRegFieldBits }
+            CLKEN { RwRwRegFieldBit Option }
+            CPOL { RwRwRegFieldBit Option }
+            CPHA { RwRwRegFieldBit Option }
+            LBCL { RwRwRegFieldBit Option }
+            LBDIE { RwRwRegFieldBit }
+            LBDL { RwRwRegFieldBit }
+            ADD { RwRwRegFieldBits }
+        }
+        CR3 {
+            0x20 RwRegBitBand;
+            ONEBIT { RwRwRegFieldBit }
+            CTSIE { RwRwRegFieldBit Option }
+            CTSE { RwRwRegFieldBit Option }
+            RTSE { RwRwRegFieldBit Option }
+            DMAT { RwRwRegFieldBit }
+            DMAR { RwRwRegFieldBit }
+            SCEN { RwRwRegFieldBit Option }
+            NACK { RwRwRegFieldBit Option }
+            HDSEL { RwRwRegFieldBit }
+            IRLP { RwRwRegFieldBit }
+            IREN { RwRwRegFieldBit }
+            EIE { RwRwRegFieldBit }
+        }
+        GTPR {
+            0x20 RwRegBitBand Option;
+            GT { RwRwRegFieldBits }
+            PSC { RwRwRegFieldBits }
+        }
+    }
+}
+
+macro_rules! map_uart {
+    (
+        $uart_macro_doc:expr,
+        $uart_macro:ident,
+        $uart_ty_doc:expr,
+        $uart_ty:ident,
+        $busenr:ident,
+        $busrstr:ident,
+        $bussmenr:ident,
+        $uarten:ident,
+        $uartrst:ident,
+        $uartsmen:ident,
+        $uart:ident,
+        ($($cts:ident)?),
+        ($($clken:ident)?),
+        ($($cpol:ident)?),
+        ($($cpha:ident)?),
+        ($($lbcl:ident)?),
+        ($($ctsie:ident)?),
+        ($($ctse:ident)?),
+        ($($rtse:ident)?),
+        ($($scen:ident)?),
+        ($($nack:ident)?),
+        ($($gtpr:ident)?),
+    ) => {
+        periph::map! {
+            #[doc = $uart_macro_doc]
+            pub macro $uart_macro;
+
+            #[doc = $uart_ty_doc]
+            pub struct $uart_ty;
+
+            impl UartMap for $uart_ty {}
+
+            drone_stm32_map_pieces::reg;
+            crate;
+
+            RCC {
+                BUSENR {
+                    $busenr Shared;
+                    UARTEN { $uarten }
+                }
+                BUSRSTR {
+                    $busrstr Shared;
+                    UARTRST { $uartrst }
+                }
+                BUSSMENR {
+                    $bussmenr Shared;
+                    UARTSMEN { $uartsmen }
+                }
+            }
+
+            UART {
+                $uart;
+                SR {
+                    SR;
+                    CTS { $($cts Option)* }
+                    LBD { LBD }
+                    TXE { TXE }
+                    TC { TC }
+                    RXNE { RXNE }
+                    IDLE { IDLE }
+                    ORE { ORE }
+                    NF { NF }
+                    FE { FE }
+                    PE { PE }
+                }
+                DR {
+                    DR;
+                    DR { DR }
+                }
+                BRR {
+                    BRR;
+                    DIV_Mantissa { DIV_Mantissa }
+                    DIV_Fraction { DIV_Fraction }
+                }
+                CR1 {
+                    CR1;
+                    OVER8 { OVER8 }
+                    UE { UE }
+                    M { M }
+                    WAKE { WAKE }
+                    PCE { PCE }
+                    PS { PS }
+                    PEIE { PEIE }
+                    TXEIE { TXEIE }
+                    TCIE { TCIE }
+                    RXNEIE { RXNEIE }
+                    IDLEIE { IDLEIE }
+                    TE { TE }
+                    RE { RE }
+                    RWU { RWU }
+                    SBK { SBK }
+                }
+                CR2 {
+                    CR2; 
+                    LINEN { LINEN }
+                    STOP { STOP }
+                    CLKEN { $($clken Option)* }
+                    CPOL { $($cpol Option)* }
+                    CPHA { $($cpha Option)* }
+                    LBCL { $($lbcl Option)* }
+                    LBDIE { LBDIE }
+                    LBDL { LBDL }
+                    ADD { ADD }
+                }
+                CR3 {
+                    CR3; 
+                    ONEBIT { ONEBIT }
+                    CTSIE { $($ctsie Option)* }
+                    CTSE { $($ctse Option)* }
+                    RTSE { $($rtse Option)* }
+                    DMAT { DMAT }
+                    DMAR { DMAR }
+                    SCEN { $($scen Option)* }
+                    NACK { $($nack Option)* }
+                    HDSEL { HDSEL }
+                    IRLP { IRLP }
+                    IREN { IREN }
+                    EIE { EIE }
+                }
+                GTPR {
+                    $(
+                        $gtpr Option;  
+                        GT { GT }
+                        PSC { PSC }
+                    )*
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f401",
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f410",
+    stm32_mcu = "stm32f411",
+    stm32_mcu = "stm32f412",
+    stm32_mcu = "stm32f413",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts USART1 register tokens.",
+    periph_usart1,
+    "USART1 peripheral variant.",
+    Usart1,
+    APB2ENR,
+    APB2RSTR,
+    APB2LPENR,
+    USART1EN,
+    USART1RST,
+    USART1LPEN,
+    USART1,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f401",
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f410",
+    stm32_mcu = "stm32f411",
+    stm32_mcu = "stm32f412",
+    stm32_mcu = "stm32f413",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts USART2 register tokens.",
+    periph_usart2,
+    "USART2 peripheral variant.",
+    Usart2,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    USART2EN,
+    UART2RST,
+    USART2LPEN,
+    USART2,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f412",
+    stm32_mcu = "stm32f413",
+    stm32_mcu = "stm32f417",
+    stm32_mcu = "stm32f437",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts USART3 register tokens.",
+    periph_usart3,
+    "USART3 peripheral variant.",
+    Usart3,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    USART3EN,
+    USART3RST,
+    USART3LPEN,
+    USART3,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+))]
+map_uart! {
+    "Extracts USART3 register tokens.",
+    periph_usart3,
+    "USART3 peripheral variant.",
+    Usart3,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    USART3EN,
+    UART3RST,
+    USART3LPEN,
+    USART3,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f417",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+    stm32_mcu = "stm32f437",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts UART4 register tokens.",
+    periph_uart4,
+    "UART4 peripheral variant.",
+    Uart4,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART4EN,
+    UART4RST,
+    UART4LPEN,
+    UART4,
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f413",
+))]
+map_uart! {
+    "Extracts UART4 register tokens.",
+    periph_uart4,
+    "UART4 peripheral variant.",
+    Uart4,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART4EN,
+    UART4RST,
+    UART4LPEN,
+    UART4,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f417",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+    stm32_mcu = "stm32f437",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts UART5 register tokens.",
+    periph_uart5,
+    "UART5 peripheral variant.",
+    Uart5,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART5EN,
+    UART5RST,
+    UART5LPEN,
+    UART5,
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f413",
+))]
+map_uart! {
+    "Extracts UART5 register tokens.",
+    periph_uart5,
+    "UART5 peripheral variant.",
+    Uart5,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART5EN,
+    UART5RST,
+    UART5LPEN,
+    UART5,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f401",
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f410",
+    stm32_mcu = "stm32f411",
+    stm32_mcu = "stm32f412",
+    stm32_mcu = "stm32f413",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts USART6 register tokens.",
+    periph_usart6,
+    "USART6 peripheral variant.",
+    Usart6,
+    APB2ENR,
+    APB2RSTR,
+    APB2LPENR,
+    USART6EN,
+    USART6RST,
+    USART6LPEN,
+    USART6,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f417",
+    stm32_mcu = "stm32f437",
+))]
+map_uart! {
+    "Extracts UART7 register tokens.",
+    periph_uart7,
+    "UART7 peripheral variant.",
+    Uart7,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART7EN,
+    UART7RST,
+    UART7LPEN,
+    UART7,
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts UART7 register tokens.",
+    periph_uart7,
+    "UART7 peripheral variant.",
+    Uart7,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART7EN,
+    UART7RST,
+    UART7LPEN,
+    UART7,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+
+#[cfg(any(
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f417",
+    stm32_mcu = "stm32f437",
+))]
+map_uart! {
+    "Extracts UART8 register tokens.",
+    periph_uart8,
+    "UART8 peripheral variant.",
+    Uart8,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART8EN,
+    UART8RST,
+    UART8LPEN,
+    UART8,
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f469",
+))]
+map_uart! {
+    "Extracts UART8 register tokens.",
+    periph_uart8,
+    "UART8 peripheral variant.",
+    Uart8,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART8EN,
+    UART8RST,
+    UART8LPEN,
+    UART8,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f413",
+))]
+map_uart! {
+    "Extracts UART8 register tokens.",
+    periph_uart8,
+    "UART8 peripheral variant.",
+    Uart8,
+    APB1ENR,
+    APB1RSTR,
+    APB1LPENR,
+    UART8EN,
+    UART8RST,
+    UART8LPEN,
+    UART8,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f413",
+))]
+map_uart! {
+    "Extracts UART9 register tokens.",
+    periph_uart9,
+    "UART9 peripheral variant.",
+    Uart9,
+    APB2ENR,
+    APB2RSTR,
+    APB2LPENR,
+    UART9EN,
+    UART9RST,
+    UART9LPEN,
+    UART9,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}
+
+#[cfg(any(
+    stm32_mcu = "stm32f413",
+))]
+map_uart! {
+    "Extracts UART10 register tokens.",
+    periph_uart10,
+    "UART10 peripheral variant.",
+    Uart10,
+    APB2ENR,
+    APB2RSTR,
+    APB2LPENR,
+    UART10EN,
+    UART10RST,
+    UART10LPEN,
+    UART10,
+    (CTS),
+    (CLKEN),
+    (CPOL),
+    (CPHA),
+    (LBCL),
+    (CTSIE),
+    (CTSE),
+    (RTSE),
+    (SCEN),
+    (NACK),
+    (GTPR),
+}

--- a/src/periph/uart/f4.rs
+++ b/src/periph/uart/f4.rs
@@ -198,7 +198,7 @@ macro_rules! map_uart {
                     SBK { SBK }
                 }
                 CR2 {
-                    CR2; 
+                    CR2;
                     LINEN { LINEN }
                     STOP { STOP }
                     CLKEN { $($clken Option)* }
@@ -210,7 +210,7 @@ macro_rules! map_uart {
                     ADD { ADD }
                 }
                 CR3 {
-                    CR3; 
+                    CR3;
                     ONEBIT { ONEBIT }
                     CTSIE { $($ctsie Option)* }
                     CTSE { $($ctse Option)* }
@@ -226,7 +226,7 @@ macro_rules! map_uart {
                 }
                 GTPR {
                     $(
-                        $gtpr Option;  
+                        $gtpr Option;
                         GT { GT }
                         PSC { PSC }
                     )*
@@ -317,8 +317,8 @@ map_uart! {
     stm32_mcu = "stm32f407",
     stm32_mcu = "stm32f412",
     stm32_mcu = "stm32f413",
-    stm32_mcu = "stm32f417",
-    stm32_mcu = "stm32f437",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
     stm32_mcu = "stm32f446",
     stm32_mcu = "stm32f469",
 ))]
@@ -348,41 +348,11 @@ map_uart! {
 }
 
 #[cfg(any(
-    stm32_mcu = "stm32f427",
-    stm32_mcu = "stm32f429",
-))]
-map_uart! {
-    "Extracts USART3 register tokens.",
-    periph_usart3,
-    "USART3 peripheral variant.",
-    Usart3,
-    APB1ENR,
-    APB1RSTR,
-    APB1LPENR,
-    USART3EN,
-    UART3RST,
-    USART3LPEN,
-    USART3,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
-}
-
-#[cfg(any(
     stm32_mcu = "stm32f405",
     stm32_mcu = "stm32f407",
-    stm32_mcu = "stm32f417",
+    stm32_mcu = "stm32f413",
     stm32_mcu = "stm32f427",
     stm32_mcu = "stm32f429",
-    stm32_mcu = "stm32f437",
     stm32_mcu = "stm32f446",
     stm32_mcu = "stm32f469",
 ))]
@@ -412,41 +382,11 @@ map_uart! {
 }
 
 #[cfg(any(
-    stm32_mcu = "stm32f413",
-))]
-map_uart! {
-    "Extracts UART4 register tokens.",
-    periph_uart4,
-    "UART4 peripheral variant.",
-    Uart4,
-    APB1ENR,
-    APB1RSTR,
-    APB1LPENR,
-    UART4EN,
-    UART4RST,
-    UART4LPEN,
-    UART4,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
-}
-
-#[cfg(any(
     stm32_mcu = "stm32f405",
     stm32_mcu = "stm32f407",
-    stm32_mcu = "stm32f405",
-    stm32_mcu = "stm32f417",
+    stm32_mcu = "stm32f413",
     stm32_mcu = "stm32f427",
     stm32_mcu = "stm32f429",
-    stm32_mcu = "stm32f437",
     stm32_mcu = "stm32f446",
     stm32_mcu = "stm32f469",
 ))]
@@ -473,34 +413,6 @@ map_uart! {
     (),
     (),
     (),
-}
-
-#[cfg(any(
-    stm32_mcu = "stm32f413",
-))]
-map_uart! {
-    "Extracts UART5 register tokens.",
-    periph_uart5,
-    "UART5 peripheral variant.",
-    Uart5,
-    APB1ENR,
-    APB1RSTR,
-    APB1LPENR,
-    UART5EN,
-    UART5RST,
-    UART5LPEN,
-    UART5,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
 }
 
 #[cfg(any(
@@ -544,36 +456,9 @@ map_uart! {
 #[cfg(any(
     stm32_mcu = "stm32f405",
     stm32_mcu = "stm32f407",
-    stm32_mcu = "stm32f417",
-    stm32_mcu = "stm32f437",
-))]
-map_uart! {
-    "Extracts UART7 register tokens.",
-    periph_uart7,
-    "UART7 peripheral variant.",
-    Uart7,
-    APB1ENR,
-    APB1RSTR,
-    APB1LPENR,
-    UART7EN,
-    UART7RST,
-    UART7LPEN,
-    UART7,
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-}
-
-#[cfg(any(
+    stm32_mcu = "stm32f413",
     stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
     stm32_mcu = "stm32f469",
 ))]
 map_uart! {
@@ -588,53 +473,25 @@ map_uart! {
     UART7RST,
     UART7LPEN,
     UART7,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
 }
-
 
 #[cfg(any(
     stm32_mcu = "stm32f405",
     stm32_mcu = "stm32f407",
-    stm32_mcu = "stm32f417",
-    stm32_mcu = "stm32f437",
-))]
-map_uart! {
-    "Extracts UART8 register tokens.",
-    periph_uart8,
-    "UART8 peripheral variant.",
-    Uart8,
-    APB1ENR,
-    APB1RSTR,
-    APB1LPENR,
-    UART8EN,
-    UART8RST,
-    UART8LPEN,
-    UART8,
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-    (),
-}
-
-#[cfg(any(
+    stm32_mcu = "stm32f413",
     stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
     stm32_mcu = "stm32f469",
 ))]
 map_uart! {
@@ -649,50 +506,20 @@ map_uart! {
     UART8RST,
     UART8LPEN,
     UART8,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
 }
 
-#[cfg(any(
-    stm32_mcu = "stm32f413",
-))]
-map_uart! {
-    "Extracts UART8 register tokens.",
-    periph_uart8,
-    "UART8 peripheral variant.",
-    Uart8,
-    APB1ENR,
-    APB1RSTR,
-    APB1LPENR,
-    UART8EN,
-    UART8RST,
-    UART8LPEN,
-    UART8,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
-}
-
-#[cfg(any(
-    stm32_mcu = "stm32f413",
-))]
+#[cfg(any(stm32_mcu = "stm32f413",))]
 map_uart! {
     "Extracts UART9 register tokens.",
     periph_uart9,
@@ -705,22 +532,20 @@ map_uart! {
     UART9RST,
     UART9LPEN,
     UART9,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
 }
 
-#[cfg(any(
-    stm32_mcu = "stm32f413",
-))]
+#[cfg(any(stm32_mcu = "stm32f413",))]
 map_uart! {
     "Extracts UART10 register tokens.",
     periph_uart10,
@@ -733,15 +558,15 @@ map_uart! {
     UART10RST,
     UART10LPEN,
     UART10,
-    (CTS),
-    (CLKEN),
-    (CPOL),
-    (CPHA),
-    (LBCL),
-    (CTSIE),
-    (CTSE),
-    (RTSE),
-    (SCEN),
-    (NACK),
-    (GTPR),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
+    (),
 }

--- a/src/periph/uart/lib.rs
+++ b/src/periph/uart/lib.rs
@@ -7,6 +7,20 @@
 #![no_std]
 
 #[cfg(any(
+    stm32_mcu = "stm32f401",
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f410",
+    stm32_mcu = "stm32f411",
+    stm32_mcu = "stm32f412",
+    stm32_mcu = "stm32f413",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+pub mod f4;
+#[cfg(any(
     stm32_mcu = "stm32l4x1",
     stm32_mcu = "stm32l4x2",
     stm32_mcu = "stm32l4x3",
@@ -24,6 +38,20 @@ pub mod l4;
 ))]
 pub mod l4_plus;
 
+#[cfg(any(
+    stm32_mcu = "stm32f401",
+    stm32_mcu = "stm32f405",
+    stm32_mcu = "stm32f407",
+    stm32_mcu = "stm32f410",
+    stm32_mcu = "stm32f411",
+    stm32_mcu = "stm32f412",
+    stm32_mcu = "stm32f413",
+    stm32_mcu = "stm32f427",
+    stm32_mcu = "stm32f429",
+    stm32_mcu = "stm32f446",
+    stm32_mcu = "stm32f469",
+))]
+pub use self::f4::*;
 #[cfg(any(
     stm32_mcu = "stm32l4x1",
     stm32_mcu = "stm32l4x2",

--- a/svd/src/lib.rs
+++ b/svd/src/lib.rs
@@ -122,6 +122,11 @@ fn patch_stm32f405(mut dev: Device) -> Result<Device> {
     adc::fix_adc_com(&mut dev)?;
     adc::fix_adc1_1(&mut dev)?;
     i2c::fix_2(&mut dev)?;
+    uart::fix_usart3_2(&mut dev)?;
+    uart::fix_uart7_1(&mut dev)?;
+    uart::fix_uart7_2(&mut dev)?;
+    uart::fix_uart8_1(&mut dev)?;
+    uart::fix_uart8_2(&mut dev)?;
     Ok(dev)
 }
 
@@ -143,6 +148,11 @@ fn patch_stm32f407(mut dev: Device) -> Result<Device> {
     adc::fix_adc_com(&mut dev)?;
     adc::fix_adc1_1(&mut dev)?;
     i2c::fix_2(&mut dev)?;
+    uart::fix_usart3_2(&mut dev)?;
+    uart::fix_uart7_1(&mut dev)?;
+    uart::fix_uart7_2(&mut dev)?;
+    uart::fix_uart8_1(&mut dev)?;
+    uart::fix_uart8_2(&mut dev)?;
     Ok(dev)
 }
 
@@ -216,6 +226,16 @@ fn patch_stm32f413(mut dev: Device) -> Result<Device> {
     rcc::fix_5(&mut dev)?;
     rcc::fix_7(&mut dev)?;
     i2c::fix_5(&mut dev)?;
+    uart::fix_uart4_2(&mut dev)?;
+    uart::fix_uart4_3(&mut dev)?;
+    uart::fix_uart5_1(&mut dev)?;
+    uart::fix_uart5_2(&mut dev)?;
+    uart::fix_uart7_3(&mut dev)?;
+    uart::fix_uart8_3(&mut dev)?;
+    uart::fix_uart9_1(&mut dev)?;
+    uart::fix_uart9_2(&mut dev)?;
+    uart::fix_uart10_1(&mut dev)?;
+    uart::fix_uart10_2(&mut dev)?;
     Ok(dev)
 }
 
@@ -236,6 +256,11 @@ fn patch_stm32f427(mut dev: Device) -> Result<Device> {
     tim::fix_tim11_2(&mut dev)?;
     adc::fix_adc_com(&mut dev)?;
     adc::fix_adc1_1(&mut dev)?;
+    uart::fix_usart3_2(&mut dev)?;
+    uart::fix_uart7_1(&mut dev)?;
+    uart::fix_uart7_3(&mut dev)?;
+    uart::fix_uart8_1(&mut dev)?;
+    uart::fix_uart8_3(&mut dev)?;
     Ok(dev)
 }
 
@@ -256,6 +281,13 @@ fn patch_stm32f429(mut dev: Device) -> Result<Device> {
     tim::fix_tim11_2(&mut dev)?;
     adc::fix_adc_com(&mut dev)?;
     adc::fix_adc1_1(&mut dev)?;
+    uart::fix_usart3_2(&mut dev)?;
+    uart::fix_uart7_1(&mut dev)?;
+    uart::fix_uart7_2(&mut dev)?;
+    uart::fix_uart7_3(&mut dev)?;
+    uart::fix_uart8_1(&mut dev)?;
+    uart::fix_uart8_2(&mut dev)?;
+    uart::fix_uart8_3(&mut dev)?;
     Ok(dev)
 }
 
@@ -273,6 +305,7 @@ fn patch_stm32f446(mut dev: Device) -> Result<Device> {
     tim::fix_tim11_1(&mut dev)?;
     adc::fix_adc_com(&mut dev)?;
     adc::fix_adc1_1(&mut dev)?;
+    uart::fix_usart3_2(&mut dev)?;
     Ok(dev)
 }
 
@@ -289,6 +322,11 @@ fn patch_stm32f469(mut dev: Device) -> Result<Device> {
     tim::fix_tim11_1(&mut dev)?;
     adc::fix_adc_com(&mut dev)?;
     adc::fix_adc1_1(&mut dev)?;
+    uart::fix_usart3_2(&mut dev)?;
+    uart::fix_uart7_1(&mut dev)?;
+    uart::fix_uart7_3(&mut dev)?;
+    uart::fix_uart8_1(&mut dev)?;
+    uart::fix_uart8_3(&mut dev)?;
     Ok(dev)
 }
 
@@ -308,10 +346,10 @@ fn patch_stm32l4x1(mut dev: Device) -> Result<Device> {
     tim::fix_tim15(&mut dev)?;
     tim::fix_tim3_1(&mut dev)?;
     tim::fix_tim3_2(&mut dev)?;
-    uart::fix_uart4(&mut dev)?;
+    uart::fix_uart4_1(&mut dev)?;
     uart::fix_usart1_1(&mut dev)?;
     uart::fix_usart1_2(&mut dev)?;
-    uart::fix_usart3(&mut dev)?;
+    uart::fix_usart3_1(&mut dev)?;
     Ok(dev)
 }
 
@@ -332,10 +370,10 @@ fn patch_stm32l4x2(mut dev: Device) -> Result<Device> {
     tim::fix_tim15(&mut dev)?;
     tim::fix_tim3_1(&mut dev)?;
     tim::fix_tim3_2(&mut dev)?;
-    uart::fix_uart4(&mut dev)?;
+    uart::fix_uart4_1(&mut dev)?;
     uart::fix_usart1_1(&mut dev)?;
     uart::fix_usart1_2(&mut dev)?;
-    uart::fix_usart3(&mut dev)?;
+    uart::fix_usart3_1(&mut dev)?;
     Ok(dev)
 }
 

--- a/svd/src/uart.rs
+++ b/svd/src/uart.rs
@@ -1,6 +1,6 @@
 //! UART peripheral patches.
 
-use crate::copy_field;
+use crate::{copy_field, copy_reg};
 use anyhow::Result;
 use drone_svd::Device;
 
@@ -21,7 +21,7 @@ pub fn fix_usart1_2(dev: &mut Device) -> Result<()> {
     Ok(())
 }
 
-pub fn fix_usart3(dev: &mut Device) -> Result<()> {
+pub fn fix_usart3_1(dev: &mut Device) -> Result<()> {
     dev.periph("RCC").reg("APB1ENR1").new_field(|field| {
         field.name = "USART3EN".to_string();
         field.description = "USART3 clock enable".to_string();
@@ -43,7 +43,12 @@ pub fn fix_usart3(dev: &mut Device) -> Result<()> {
     Ok(())
 }
 
-pub fn fix_uart4(dev: &mut Device) -> Result<()> {
+pub fn fix_usart3_2(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB1RSTR").field("UART3RST").name = "USART3RST".to_string();
+    Ok(())
+}
+
+pub fn fix_uart4_1(dev: &mut Device) -> Result<()> {
     dev.periph("RCC").reg("APB1RSTR1").new_field(|field| {
         field.name = "UART4RST".to_string();
         field.description = "UART4 reset".to_string();
@@ -57,6 +62,182 @@ pub fn fix_uart4(dev: &mut Device) -> Result<()> {
         field.bit_width = Some(1);
     });
     dev.periph("RCC").reg("CCIPR").field("USART4SEL").name = "UART4SEL".to_string();
+    Ok(())
+}
+
+pub fn fix_uart4_2(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB1RSTR").new_field(|field| {
+        field.name = "UART4RST".to_string();
+        field.description = "UART4 reset".to_string();
+        field.bit_offset = Some(19);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB1LPENR").new_field(|field| {
+        field.name = "UART4LPEN".to_string();
+        field.description = "UART4 clock enable during Sleep mode".to_string();
+        field.bit_offset = Some(19);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart4_3(dev: &mut Device) -> Result<()> {
+    copy_reg(dev, "USART3", "UART4", "SR");
+    copy_reg(dev, "USART3", "UART4", "DR");
+    copy_reg(dev, "USART3", "UART4", "BRR");
+    copy_reg(dev, "USART3", "UART4", "CR1");
+    copy_reg(dev, "USART3", "UART4", "CR2");
+    copy_reg(dev, "USART3", "UART4", "CR3");
+    dev.periph("UART4").derived_from = None;
+    dev.periph("UART4").description =
+        Some("Universal asynchronous receiver transmitter".to_string());
+    dev.periph("UART4").reg("SR").remove_field("CTS");
+    dev.periph("UART4").reg("CR2").remove_field("CLKEN");
+    dev.periph("UART4").reg("CR2").remove_field("CPOL");
+    dev.periph("UART4").reg("CR2").remove_field("CPHA");
+    dev.periph("UART4").reg("CR2").remove_field("LBCL");
+    dev.periph("UART4").reg("CR3").remove_field("CTSIE");
+    dev.periph("UART4").reg("CR3").remove_field("CTSE");
+    dev.periph("UART4").reg("CR3").remove_field("RTSE");
+    dev.periph("UART4").reg("CR3").remove_field("SCEN");
+    dev.periph("UART4").reg("CR3").remove_field("NACK");
+    Ok(())
+}
+
+pub fn fix_uart5_1(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB1RSTR").new_field(|field| {
+        field.name = "UART5RST".to_string();
+        field.description = "UART5 reset".to_string();
+        field.bit_offset = Some(20);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB1LPENR").new_field(|field| {
+        field.name = "UART5LPEN".to_string();
+        field.description = "UART5 clock enable during Sleep mode".to_string();
+        field.bit_offset = Some(20);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart5_2(dev: &mut Device) -> Result<()> {
+    dev.periph("UART5").derived_from = Some("UART4".to_string());
+    Ok(())
+}
+
+pub fn fix_uart7_1(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB1ENR").new_field(|field| {
+        field.name = "UART7EN".to_string();
+        field.description = "UART7 clock enable".to_string();
+        field.bit_offset = Some(30);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart7_2(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB1RSTR").new_field(|field| {
+        field.name = "UART7RST".to_string();
+        field.description = "UART7 reset".to_string();
+        field.bit_offset = Some(30);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB1LPENR").new_field(|field| {
+        field.name = "UART7LPEN".to_string();
+        field.description = "UART7 clock enable during Sleep mode".to_string();
+        field.bit_offset = Some(30);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart7_3(dev: &mut Device) -> Result<()> {
+    dev.periph("UART7").derived_from = Some("UART4".to_string());
+    Ok(())
+}
+
+pub fn fix_uart8_1(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB1ENR").new_field(|field| {
+        field.name = "UART8EN".to_string();
+        field.description = "UART8 clock enable".to_string();
+        field.bit_offset = Some(31);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart8_2(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB1RSTR").new_field(|field| {
+        field.name = "UART8RST".to_string();
+        field.description = "UART8 reset".to_string();
+        field.bit_offset = Some(32);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB1LPENR").new_field(|field| {
+        field.name = "UART8LPEN".to_string();
+        field.description = "UART8 clock enable during Sleep mode".to_string();
+        field.bit_offset = Some(31);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart8_3(dev: &mut Device) -> Result<()> {
+    dev.periph("UART8").derived_from = Some("UART4".to_string());
+    Ok(())
+}
+
+pub fn fix_uart9_1(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB2ENR").new_field(|field| {
+        field.name = "UART9EN".to_string();
+        field.description = "UART9 clock enable".to_string();
+        field.bit_offset = Some(6);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB2RSTR").new_field(|field| {
+        field.name = "UART9RST".to_string();
+        field.description = "UART9 reset".to_string();
+        field.bit_offset = Some(6);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB2LPENR").new_field(|field| {
+        field.name = "UART9LPEN".to_string();
+        field.description = "UART9 clock enable during Sleep mode".to_string();
+        field.bit_offset = Some(6);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart9_2(dev: &mut Device) -> Result<()> {
+    dev.periph("UART9").derived_from = Some("UART4".to_string());
+    Ok(())
+}
+
+pub fn fix_uart10_1(dev: &mut Device) -> Result<()> {
+    dev.periph("RCC").reg("APB2ENR").new_field(|field| {
+        field.name = "UART10EN".to_string();
+        field.description = "UART10 clock enable".to_string();
+        field.bit_offset = Some(7);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB2RSTR").new_field(|field| {
+        field.name = "UART10RST".to_string();
+        field.description = "UART10 reset".to_string();
+        field.bit_offset = Some(7);
+        field.bit_width = Some(1);
+    });
+    dev.periph("RCC").reg("APB2LPENR").new_field(|field| {
+        field.name = "UART10LPEN".to_string();
+        field.description = "UART10 clock enable during Sleep mode".to_string();
+        field.bit_offset = Some(7);
+        field.bit_width = Some(1);
+    });
+    Ok(())
+}
+
+pub fn fix_uart10_2(dev: &mut Device) -> Result<()> {
+    dev.periph("UART10").derived_from = Some("UART4".to_string());
     Ok(())
 }
 

--- a/tests/periph_macros.rs
+++ b/tests/periph_macros.rs
@@ -1120,6 +1120,72 @@ fn periph_macros1() {
     #[cfg(all(
         feature = "uart",
         any(
+            stm32_mcu = "stm32f401",
+            stm32_mcu = "stm32f405",
+            stm32_mcu = "stm32f407",
+            stm32_mcu = "stm32f410",
+            stm32_mcu = "stm32f411",
+            stm32_mcu = "stm32f412",
+            stm32_mcu = "stm32f413",
+            stm32_mcu = "stm32f427",
+            stm32_mcu = "stm32f429",
+            stm32_mcu = "stm32f446",
+            stm32_mcu = "stm32f469",
+        )
+    ))]
+    {
+        let usart1 = drone_stm32_map::periph::uart::periph_usart1!(reg);
+        let usart2 = drone_stm32_map::periph::uart::periph_usart2!(reg);
+        let usart6 = drone_stm32_map::periph::uart::periph_usart6!(reg);
+    }
+    #[cfg(all(
+        feature = "uart",
+        any(
+            stm32_mcu = "stm32f405",
+            stm32_mcu = "stm32f407",
+            stm32_mcu = "stm32f413",
+            stm32_mcu = "stm32f417",
+            stm32_mcu = "stm32f427",
+            stm32_mcu = "stm32f429",
+            stm32_mcu = "stm32f437",
+            stm32_mcu = "stm32f446",
+            stm32_mcu = "stm32f469",
+        )
+    ))]
+    {
+        let usart3 = drone_stm32_map::periph::uart::periph_usart3!(reg);
+        let uart4 = drone_stm32_map::periph::uart::periph_uart4!(reg);
+        let uart5 = drone_stm32_map::periph::uart::periph_uart5!(reg);
+    }
+    #[cfg(all(
+        feature = "uart",
+        any(
+            stm32_mcu = "stm32f405",
+            stm32_mcu = "stm32f407",
+            stm32_mcu = "stm32f417",
+            stm32_mcu = "stm32f427",
+            stm32_mcu = "stm32f437",
+            stm32_mcu = "stm32f469",
+        )
+    ))]
+    {
+        let uart7 = drone_stm32_map::periph::uart::periph_uart7!(reg);
+        let uart8 = drone_stm32_map::periph::uart::periph_uart8!(reg);
+    }
+
+    #[cfg(all(
+        feature = "uart",
+        any(
+            stm32_mcu = "stm32f413",
+        )
+    ))]
+    {
+        let uart9 = drone_stm32_map::periph::uart::periph_uart9!(reg);
+        let uart10 = drone_stm32_map::periph::uart::periph_uart10!(reg);
+    }
+    #[cfg(all(
+        feature = "uart",
+        any(
             stm32_mcu = "stm32l4r5",
             stm32_mcu = "stm32l4r7",
             stm32_mcu = "stm32l4r9",

--- a/tests/periph_macros.rs
+++ b/tests/periph_macros.rs
@@ -1143,17 +1143,30 @@ fn periph_macros1() {
         any(
             stm32_mcu = "stm32f405",
             stm32_mcu = "stm32f407",
+            stm32_mcu = "stm32f412",
             stm32_mcu = "stm32f413",
-            stm32_mcu = "stm32f417",
             stm32_mcu = "stm32f427",
             stm32_mcu = "stm32f429",
-            stm32_mcu = "stm32f437",
             stm32_mcu = "stm32f446",
             stm32_mcu = "stm32f469",
         )
     ))]
     {
         let usart3 = drone_stm32_map::periph::uart::periph_usart3!(reg);
+    }
+    #[cfg(all(
+        feature = "uart",
+        any(
+            stm32_mcu = "stm32f405",
+            stm32_mcu = "stm32f407",
+            stm32_mcu = "stm32f413",
+            stm32_mcu = "stm32f427",
+            stm32_mcu = "stm32f429",
+            stm32_mcu = "stm32f446",
+            stm32_mcu = "stm32f469",
+        )
+    ))]
+    {
         let uart4 = drone_stm32_map::periph::uart::periph_uart4!(reg);
         let uart5 = drone_stm32_map::periph::uart::periph_uart5!(reg);
     }
@@ -1162,9 +1175,9 @@ fn periph_macros1() {
         any(
             stm32_mcu = "stm32f405",
             stm32_mcu = "stm32f407",
-            stm32_mcu = "stm32f417",
+            stm32_mcu = "stm32f413",
             stm32_mcu = "stm32f427",
-            stm32_mcu = "stm32f437",
+            stm32_mcu = "stm32f429",
             stm32_mcu = "stm32f469",
         )
     ))]
@@ -1173,12 +1186,7 @@ fn periph_macros1() {
         let uart8 = drone_stm32_map::periph::uart::periph_uart8!(reg);
     }
 
-    #[cfg(all(
-        feature = "uart",
-        any(
-            stm32_mcu = "stm32f413",
-        )
-    ))]
+    #[cfg(all(feature = "uart", any(stm32_mcu = "stm32f413",)))]
     {
         let uart9 = drone_stm32_map::periph::uart::periph_uart9!(reg);
         let uart10 = drone_stm32_map::periph::uart::periph_uart10!(reg);


### PR DESCRIPTION
On the first commit I picked up the changes related to UART peripheral from @alfredch's [f4-uart](https://github.com/drone-os/drone-stm32-map/tree/f4-uart) branch.

On the second commit I fixed UART bindings to conform with referance manuals.